### PR TITLE
#205 skip form validation, if min => 0 & input not exist

### DIFF
--- a/src/DynamicFormWidget.php
+++ b/src/DynamicFormWidget.php
@@ -218,6 +218,15 @@ class DynamicFormWidget extends \yii\base\Widget
 
         $js = 'jQuery("#' . $this->formId . '").yiiDynamicForm(' . $this->_hashVar .');' . "\n";
         $view->registerJs($js, $view::POS_LOAD);
+
+        // skip attribute validation if input not exist in yiiActiveForm.beforeValidateAttribute event
+        if (isset($this->_options['min']) && $this->_options['min'] === 0){
+            $js = 'jQuery("#' . $this->formId . '").on("beforeValidateAttribute", function(event, attribute){' . "\n";
+            $js .= "    if($(attribute.input).length == 0)\n";
+            $js .= "        return false;\n";
+            $js .= "});\n";
+            $view->registerJs($js, $view::POS_LOAD);
+        }
     }
 
     /**


### PR DESCRIPTION
is have an opened issue #205

this fixed it:
on form beforeValidateAttribute event we check the attribute's input is exist,
if not exist we return false, so we dont validate this attribute

otherwise:
form validation have error on not exist element
so the form submitted(yiiActiveform.js don't find form-group with has-error class), but the errorSummary updated to and show errors for non-exist inputs