### PR TITLE
Type Error $toclone.clone is not a function

### DIFF
--- a/src/assets/yii2-dynamic-form.js
+++ b/src/assets/yii2-dynamic-form.js
@@ -115,7 +115,7 @@
         var count = _count($elem, widgetOptions);
 
         if (count < widgetOptions.limit) {
-            $toclone = widgetOptions.template;
+            $toclone = $(widgetOptions.template);
             $newclone = $toclone.clone(false, false);
 
             if (widgetOptions.insertPosition === 'top') {


### PR DESCRIPTION
I was getting this error while creating multiple form functionality. This error was occurring during click on add more button.