### PR TITLE
Fixed https://github.com/wbraganca/yii2-dynamicform/issues/258.

### DIFF
--- a/src/assets/yii2-dynamic-form.js
+++ b/src/assets/yii2-dynamic-form.js
@@ -115,7 +115,7 @@
         var count = _count($elem, widgetOptions);
 
         if (count < widgetOptions.limit) {
-            $toclone = widgetOptions.template;
+            $toclone = $(widgetOptions.template);
             $newclone = $toclone.clone(false, false);
 
             if (widgetOptions.insertPosition === 'top') {


### PR DESCRIPTION
Uncaught TypeError: $toclone.clone is not a function still fail 24.08.18