### PR TITLE
Update the dependencies in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
     ],
     "require": {
         "yiisoft/yii2": "~2.0.5",
-        "symfony/css-selector": "~2.8|~3.0",
-        "symfony/dom-crawler": "~2.8|~3.0"
+        "symfony/css-selector": ">=2.8 <6.0",
+        "symfony/dom-crawler": ">=2.8 <6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Currently this package depends on quite old versions of the `symfony/dom-crawler` and `symfony/css-selector` packages (versions ~2.8 and ~3.0). This makes the package incompatible with other packages requiring higher versions of these dependencies.

I have tested and `yii2-dynamicform` works fine with the 5.x version of `symfony/dom-crawler` and `symfony/css-selector`, hence I submit this PR to update these dependencies in `composer.json`.