### PR TITLE
Adding custom attribute to createMultiple

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,9 +335,10 @@ class Model extends \yii\base\Model
      *
      * @param string $modelClass
      * @param array $multipleModels
+     * @param array $customAttr Definning custom model attribute where key the attribute name and value its value
      * @return array
      */
-    public static function createMultiple($modelClass, $multipleModels = [])
+    public static function createMultiple($modelClass, $multipleModels = [], $customAttr = null)
     {
         $model    = new $modelClass;
         $formName = $model->formName();
@@ -354,7 +355,7 @@ class Model extends \yii\base\Model
                 if (isset($item['id']) && !empty($item['id']) && isset($multipleModels[$item['id']])) {
                     $models[] = $multipleModels[$item['id']];
                 } else {
-                    $models[] = new $modelClass;
+                    $models[] = new $modelClass($customAttr);
                 }
             }
         }


### PR DESCRIPTION
Suppose we have to use virtual attribute that uses external value from other unsaved model, post request, etc. We have to create setter and getter of that attribute and supply its value as the third optional parameter of `createMultiple()`  like the following:

 $invoiceItems = Model::createMultiple(InvoiceItems::class, $invoiceItems,['invoiceType' => $model->type]);